### PR TITLE
Clap changed to configure_me in wired

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -6,6 +6,9 @@ authors = ["Dr. Maxim Orlovsky <orlovsky@pandoracore.com>"]
 license = "MIT"
 edition = "2018"
 
+[package.metadata.configure_me]
+spec = "config_spec.toml"
+
 [dependencies]
 dotenv = "~0.15"
 clap = { git = "https://github.com/clap-rs/clap.git" }
@@ -20,8 +23,13 @@ futures = "~0.3"
 zmq = "~0.9"
 tiny_http = "~0.6"
 prometheus = "~0.8"
+configure_me = "0.3.3"
+serde_derive = "1"
 
 lnpbp = { git = "https://github.com/lnp-bp/rust-lnpbp", features = ["all"] }
+
+[build-dependencies]
+configure_me_codegen = "0.3.12"
 
 # lnpbp requires custom version of bitcoin, so to maintain type compatibility
 # we have to use library through lnpbp::bitcoin handle and not via direct

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -24,6 +24,7 @@ zmq = "~0.9"
 tiny_http = "~0.6"
 prometheus = "~0.8"
 configure_me = "0.3.3"
+serde = "1"
 serde_derive = "1"
 
 lnpbp = { git = "https://github.com/lnp-bp/rust-lnpbp", features = ["all"] }

--- a/build.rs
+++ b/build.rs
@@ -1,0 +1,3 @@
+fn main() -> Result<(), configure_me_codegen::Error> {
+    configure_me_codegen::build_script_auto()
+}

--- a/config_spec.toml
+++ b/config_spec.toml
@@ -32,7 +32,7 @@ name = "monitor"
 type = "std::net::SocketAddr"
 abbr = "m"
 doc = "Address for Prometheus monitoring information exporter"
-default = "crate::wired::config::monitor_addr_default()"
+default = "crate::wired::config::MONITOR_ADDR_DEFAULT.parse().expect(\"Failed to parse constant MONITOR_ADDR_DEFAULT\")"
 
 [[param]]
 name = "connect"

--- a/config_spec.toml
+++ b/config_spec.toml
@@ -33,3 +33,11 @@ type = "std::net::SocketAddr"
 abbr = "m"
 doc = "Address for Prometheus monitoring information exporter"
 default = "crate::wired::config::monitor_addr_default()"
+
+[[param]]
+name = "connect"
+type = "crate::wired::config::Connect"
+abbr = "C"
+doc = "Nodes to connect to after launch (argument can be repeated)"
+merge_fn = "crate::wired::config::Connect::merge"
+default = "Default::default()"

--- a/config_spec.toml
+++ b/config_spec.toml
@@ -1,0 +1,35 @@
+[general]
+env_prefix = "LNP_WIRED"
+conf_file_param = "config"
+conf_dir_param = "conf_dir"
+doc = """
+LNP wired is a new Lightning Network node written in Rust. Actually, it's a suite of daemons able to run generalized Lightning Network protocol.
+
+The main advantage of wired over its competitors is the ability to implement future upgrades more easily and support for layer 3 protocols."""
+
+[[switch]]
+name = "verbose"
+abbr = "v"
+doc = "Sets verbosity level; can be used multiple times to increase verbosity"
+count = true
+
+[[param]]
+name = "inet_addr"
+type = "lnpbp::internet::InetAddr"
+abbr = "i"
+doc = "IPv4, IPv6 or Tor address to listen for incoming connections from LN peers"
+default = "[0, 0, 0, 0].into()"
+
+[[param]]
+name = "port"
+type = "u16"
+abbr = "p"
+doc = "Use custom port to listen for incoming connections from LN peers"
+default = "9735"
+
+[[param]]
+name = "monitor"
+type = "std::net::SocketAddr"
+abbr = "m"
+doc = "Address for Prometheus monitoring information exporter"
+default = "crate::wired::config::monitor_addr_default()"

--- a/src/bin/wired.rs
+++ b/src/bin/wired.rs
@@ -15,7 +15,6 @@
 
 use std::env;
 use log::*;
-use clap::derive::Clap;
 
 use lnp_node::BootstrapError;
 use lnp_node::service::*;
@@ -23,9 +22,8 @@ use lnp_node::wired::*;
 
 #[tokio::main]
 async fn main() -> Result<(), BootstrapError> {
-    // TODO: Parse config file as well
-    let opts: Opts = Opts::parse();
-    let config: Config = opts.into();
+    let config = Config::gather_or_exit();
+
 
     if env::var("RUST_LOG").is_err() {
         env::set_var("RUST_LOG", match config.verbose {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -42,6 +42,9 @@ extern crate chrono;
 extern crate tiny_http;
 extern crate prometheus;
 extern crate lnpbp;
+#[macro_use]
+extern crate serde_derive;
+extern crate configure_me;
 
 pub mod msgbus;
 pub mod service;

--- a/src/wired/config.rs
+++ b/src/wired/config.rs
@@ -13,53 +13,21 @@
 
 
 use std::net::SocketAddr;
-use clap::Clap;
+use std::convert::TryInto;
 
-use lnpbp::internet::{InetSocketAddr, InetAddr};
-use lnpbp::lnp::NodeAddr;
+use lnpbp::internet::InetSocketAddr;
 
 use crate::msgbus::constants::*;
 
-const MONITOR_ADDR_DEFAULT: &str = "0.0.0.0:9666";
-
-#[derive(Clap)]
-#[clap(
-    name = "wired",
-    version = "0.0.1",
-    author = "Dr Maxim Orlovsky <orlovsky@pandoracore.com>",
-    about =  "LNP wired: Lightning wire P2P daemon; part of Lightning network protocol suite"
-)]
-pub struct Opts {
-    /// Path and name of the configuration file
-    #[clap(short = "c", long = "config", default_value = "wired.toml")]
-    pub config: String,
-
-    /// Sets verbosity level; can be used multiple times to increase verbosity
-    #[clap(global = true, short = "v", long = "verbose", min_values = 0, max_values = 4, parse(from_occurrences))]
-    pub verbose: u8,
-
-    /// IPv4, IPv6 or Tor address to listen for incoming connections from LN peers
-    #[clap(short = "i", long = "inet-addr", default_value = "0.0.0.0", env="LNP_WIRED_INET_ADDR",
-           parse(try_from_str))]
-    address: InetAddr,
-
-    /// Use custom port to listen for incoming connections from LN peers
-    #[clap(short = "p", long = "port", default_value = "9735", env="LNP_WIRED_PORT")]
-    port: u16,
-
-    /// Address for Prometheus monitoring information exporter
-    #[clap(short = "m", long = "monitor", default_value = MONITOR_ADDR_DEFAULT, env="LNP_WIRED_MONITOR",
-           parse(try_from_str))]
-    monitor: SocketAddr,
-
-    // TODO: Use connect argument for connecting to the nodes after the launch
-    /// Nodes to connect at after the launch
-    /// (in form of `<node_id>@<inet_addr>[:<port>]`,
-    /// where <inet_addr> can be IPv4, IPv6 or TORv3 internet address)
-    #[clap(short = "C", long = "connect", min_values=0, env="LNP_WIRED_CONNECT")]
-    connect: Vec<NodeAddr>,
+mod internal {
+    #![allow(unused)]
+    include!(concat!(env!("OUT_DIR"), "/configure_me_config.rs"));
 }
 
+// Needs to be fn instead of const due to SocketAddr::new() not being const
+fn monitor_addr_default() -> SocketAddr {
+    SocketAddr::new([0, 0, 0, 0].into(), 9666)
+}
 
 // We need config structure since not all of the parameters can be specified
 // via environment and command-line arguments. Thus we need a config file and
@@ -74,13 +42,20 @@ pub struct Config {
     pub msgbus_peer_push_addr: String,
 }
 
-impl From<Opts> for Config {
-    fn from(opts: Opts) -> Self {
-        Self {
-            verbose: opts.verbose,
-            lnp2p_addr: InetSocketAddr::new(opts.address, opts.port),
-            monitor_addr: opts.monitor,
-            ..Config::default()
+impl Config {
+    /// Gathers the configuration from arguments, env vars and config files, exits on error.
+    pub fn gather_or_exit() -> Self {
+        use self::internal::ResultExt;
+
+        let (config, _) = internal::Config::including_optional_config_files(std::iter::empty::<&str>())
+            .unwrap_or_exit();
+
+        Config {
+            verbose: config.verbose.try_into().unwrap_or_else(|_| 4),
+            lnp2p_addr: InetSocketAddr::new(config.inet_addr, config.port),
+            monitor_addr: config.monitor,
+            msgbus_peer_api_addr: MSGBUS_PEER_API_ADDR.to_string(),
+            msgbus_peer_push_addr: MSGBUS_PEER_PUSH_ADDR.to_string()
         }
     }
 }
@@ -90,7 +65,7 @@ impl Default for Config {
         Self {
             verbose: 0,
             lnp2p_addr: InetSocketAddr::default(),
-            monitor_addr: MONITOR_ADDR_DEFAULT.parse().expect("Constant default value parse fail"),
+            monitor_addr: monitor_addr_default(),
             msgbus_peer_api_addr: MSGBUS_PEER_API_ADDR.to_string(),
             msgbus_peer_push_addr: MSGBUS_PEER_PUSH_ADDR.to_string()
         }

--- a/src/wired/config.rs
+++ b/src/wired/config.rs
@@ -23,6 +23,8 @@ use lnpbp::lnp::NodeAddr;
 use crate::msgbus::constants::*;
 use configure_me::parse_arg::ParseArgFromStr;
 
+const MONITOR_ADDR_DEFAULT: &str = "0.0.0.0:9666";
+
 mod internal {
     #![allow(unused)]
     include!(concat!(env!("OUT_DIR"), "/configure_me_config.rs"));
@@ -49,11 +51,6 @@ impl ParseArgFromStr for Connect {
     fn describe_type<W: fmt::Write>(mut writer: W) -> fmt::Result {
         write!(writer, "node address in form of <node_id>@<inet_addr>[:<port>] where <inet_addr> can be IPv4, IPv6 or TORv3 internet address")
     }
-}
-
-// Needs to be fn instead of const due to SocketAddr::new() not being const
-fn monitor_addr_default() -> SocketAddr {
-    SocketAddr::new([0, 0, 0, 0].into(), 9666)
 }
 
 // We need config structure since not all of the parameters can be specified
@@ -92,7 +89,7 @@ impl Default for Config {
         Self {
             verbose: 0,
             lnp2p_addr: InetSocketAddr::default(),
-            monitor_addr: monitor_addr_default(),
+            monitor_addr: MONITOR_ADDR_DEFAULT.parse().expect("Failed to parse constant MONITOR_ADDR_DEFAULT"),
             msgbus_peer_api_addr: MSGBUS_PEER_API_ADDR.to_string(),
             msgbus_peer_push_addr: MSGBUS_PEER_PUSH_ADDR.to_string()
         }


### PR DESCRIPTION
This implements basic changes to use `configure_me` instead of `clap`
for managing the configuration. This instantly allows us to pull the
configuration from files, directories containing files and to generate
man pages or other integrations that will be developed in `configure_me`
in the future.

So far, this is missing `connect` because it wasn't used and
`configure_me` doesn't support parsing multiple arguments into arrays
yet.

Closes #9

Currently blocked on https://github.com/LNP-BP/rust-lnpbp/pull/34