### PR TITLE
use the expanded path when creating the data dir

### DIFF
--- a/src/opts.rs
+++ b/src/opts.rs
@@ -168,7 +168,7 @@ impl Opts {
             shellexpand::tilde(&me.data_dir.to_string_lossy().to_string())
                 .to_string(),
         );
-        fs::create_dir_all(&self.data_dir)
+        fs::create_dir_all(&me.data_dir)
             .expect("Unable to access data directory");
 
         for s in vec![&mut self.msg_socket, &mut self.ctl_socket] {


### PR DESCRIPTION
Fixes the following error when starting the node for the first time:
thread 'main' panicked at 'Unable to create key file '/home/richi/.lnp_node/key.dat'; please check that the path exists: Os { code: 2, kind: NotFound, message: "No such file or directory" }', src/peerd/opts.rs:139:61