### PR TITLE
Interop with another LN implementations

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -241,6 +241,8 @@ dependencies = [
  "bp-dbc",
  "bp-seals",
  "commit_verify",
+ "serde 1.0.139",
+ "serde_with",
  "single_use_seals",
  "strict_encoding",
 ]
@@ -256,6 +258,8 @@ dependencies = [
  "bitcoin_scripts",
  "commit_verify",
  "secp256k1",
+ "serde 1.0.139",
+ "serde_with",
  "strict_encoding",
 ]
 
@@ -271,6 +275,8 @@ dependencies = [
  "bp-dbc",
  "commit_verify",
  "lnpbp_bech32",
+ "serde 1.0.139",
+ "serde_with",
  "single_use_seals",
  "strict_encoding",
 ]
@@ -374,6 +380,7 @@ dependencies = [
  "js-sys",
  "num-integer",
  "num-traits 0.2.15",
+ "serde 1.0.139",
  "time",
  "wasm-bindgen",
  "winapi",
@@ -476,6 +483,8 @@ dependencies = [
  "amplify",
  "bitcoin_hashes",
  "rand 0.8.5",
+ "serde 1.0.139",
+ "serde_with",
  "strict_encoding",
 ]
 
@@ -917,6 +926,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3f9eec918d3f24069decb9af1554cad7c880e2da24a9afd88aca000531ab82c1"
 
 [[package]]
+name = "form_urlencoded"
+version = "1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a9c384f161156f5260c24a097c56119f9be8c798586aecc13afbcbe7b7e26bf8"
+dependencies = [
+ "percent-encoding",
+]
+
+[[package]]
 name = "generic-array"
 version = "0.14.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1023,6 +1041,16 @@ name = "ident_case"
 version = "1.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b9e0384b61958566e926dc50660321d12159025e767c18e043daf26b70104c39"
+
+[[package]]
+name = "idna"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e14ddfc70884202db2244c223200c204c2bda1bc6e0998d11b5e024d657209e6"
+dependencies = [
+ "unicode-bidi",
+ "unicode-normalization",
+]
 
 [[package]]
 name = "indexmap"
@@ -1248,6 +1276,7 @@ dependencies = [
  "amplify",
  "clap",
  "clap_complete",
+ "colored",
  "configure_me_codegen",
  "internet2",
  "lightning-invoice",
@@ -1261,7 +1290,7 @@ dependencies = [
 [[package]]
 name = "lnp-core"
 version = "0.9.1"
-source = "git+https://github.com/crisdut/lnp-core?branch=exp/ln-interop#001086387a8882f65ce650df6732ab2fa6278ff9"
+source = "git+https://github.com/crisdut/lnp-core?branch=exp/ln-interop#5c7b275764f97da052e7e362b103957e7e2db71a"
 dependencies = [
  "amplify",
  "bitcoin",
@@ -1280,7 +1309,7 @@ dependencies = [
 [[package]]
 name = "lnp2p"
 version = "0.9.1"
-source = "git+https://github.com/crisdut/lnp-core?branch=exp/ln-interop#001086387a8882f65ce650df6732ab2fa6278ff9"
+source = "git+https://github.com/crisdut/lnp-core?branch=exp/ln-interop#5c7b275764f97da052e7e362b103957e7e2db71a"
 dependencies = [
  "amplify",
  "bitcoin",
@@ -1323,6 +1352,7 @@ dependencies = [
  "lnp-core",
  "lnp_rpc",
  "lnpbp",
+ "lnpbp-invoice",
  "log",
  "microservices",
  "miniscript",
@@ -1349,6 +1379,7 @@ dependencies = [
  "lightning-invoice",
  "lnp-core",
  "lnpbp",
+ "lnpbp-invoice",
  "log",
  "microservices",
  "serde 1.0.139",
@@ -1370,6 +1401,30 @@ dependencies = [
  "serde 1.0.139",
  "serde_with",
  "strict_encoding",
+]
+
+[[package]]
+name = "lnpbp-invoice"
+version = "0.9.0"
+source = "git+https://github.com/crisdut/invoices?branch=feat/bolt11#c3fc5d6e153729b584fd09cd8db6be64bb43165a"
+dependencies = [
+ "amplify",
+ "bitcoin",
+ "bitcoin_scripts",
+ "bp-core",
+ "chrono",
+ "commit_verify",
+ "descriptor-wallet",
+ "internet2",
+ "lightning",
+ "lightning-invoice",
+ "lnp-core",
+ "lnpbp",
+ "miniscript",
+ "serde 1.0.139",
+ "serde_with",
+ "strict_encoding",
+ "url",
 ]
 
 [[package]]
@@ -1467,6 +1522,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "123a10aae81d0712ecc09b780f6f0ae0b0f506a5c4c912974725760d59ba073e"
 dependencies = [
  "bitcoin",
+ "serde 1.0.139",
 ]
 
 [[package]]
@@ -1559,6 +1615,12 @@ name = "paste"
 version = "1.0.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0c520e05135d6e763148b6426a837e239041653ba7becd2e538c076c738025fc"
+
+[[package]]
+name = "percent-encoding"
+version = "2.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "478c572c3d73181ff3c2539045f6eb99e5491218eae919370993b890cdbdd98e"
 
 [[package]]
 name = "pin-project-lite"
@@ -2259,6 +2321,21 @@ dependencies = [
 ]
 
 [[package]]
+name = "tinyvec"
+version = "1.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "87cc5ceb3875bb20c2890005a4e226a4651264a5c75edb2421b52861a0a0cb50"
+dependencies = [
+ "tinyvec_macros",
+]
+
+[[package]]
+name = "tinyvec_macros"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1f3ccbac311fea05f86f61904b462b55fb3df8837a366dfc601a0161d0532f20"
+
+[[package]]
 name = "tokio"
 version = "1.19.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2305,10 +2382,25 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "dcf81ac59edc17cc8697ff311e8f5ef2d99fcbd9817b34cec66f90b6c3dfd987"
 
 [[package]]
+name = "unicode-bidi"
+version = "0.3.10"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d54675592c1dbefd78cbd98db9bacd89886e1ca50692a0692baefffdeb92dd58"
+
+[[package]]
 name = "unicode-ident"
 version = "1.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5bd2fe26506023ed7b5e1e315add59d6f584c621d037f9368fea9cfb988f368c"
+
+[[package]]
+name = "unicode-normalization"
+version = "0.1.22"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5c5713f0fc4b5db668a2ac63cdb7bb4469d8c9fed047b1d0292cc7b0ce2ba921"
+dependencies = [
+ "tinyvec",
+]
 
 [[package]]
 name = "unicode-segmentation"
@@ -2349,6 +2441,18 @@ name = "untrusted"
 version = "0.7.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a156c684c91ea7d62626509bce3cb4e1d9ed5c4d978f7b4352658f96a4c26b4a"
+
+[[package]]
+name = "url"
+version = "2.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0d68c799ae75762b8c3fe375feb6600ef5602c883c5d21eb51c09f22b83c4643"
+dependencies = [
+ "form_urlencoded",
+ "idna",
+ "percent-encoding",
+ "serde 1.0.139",
+]
 
 [[package]]
 name = "version-compare"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1193,8 +1193,7 @@ dependencies = [
 [[package]]
 name = "lightning_encoding"
 version = "0.9.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a56f420c81ea9f113a2ccefffc55124394feddf19f5b10ebbad81edee4763d28"
+source = "git+https://github.com/crisdut/lightning_encoding?branch=fix/script-decode#e5635a52b71beda2a3e5ccf584161a992dee3ea8"
 dependencies = [
  "amplify",
  "bitcoin",
@@ -1208,8 +1207,7 @@ dependencies = [
 [[package]]
 name = "lightning_encoding_derive"
 version = "0.9.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1d0f5261aacd87fa76a12ff80b5d0e6782ce969c0301ab7cfbabe20f4492881d"
+source = "git+https://github.com/crisdut/lightning_encoding?branch=fix/script-decode#e5635a52b71beda2a3e5ccf584161a992dee3ea8"
 dependencies = [
  "amplify_syn",
  "encoding_derive_helpers",
@@ -1263,8 +1261,7 @@ dependencies = [
 [[package]]
 name = "lnp-core"
 version = "0.9.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "238ce14de0c3ceccef8a31317d06964949881c6d8e4898df3076e86bae58ad67"
+source = "git+https://github.com/crisdut/lnp-core?branch=exp/ln-interop#001086387a8882f65ce650df6732ab2fa6278ff9"
 dependencies = [
  "amplify",
  "bitcoin",
@@ -1283,8 +1280,7 @@ dependencies = [
 [[package]]
 name = "lnp2p"
 version = "0.9.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b27ed14a42f7d90e3a16ff602b877e73a9af9a255416e92841ba839c7d138390"
+source = "git+https://github.com/crisdut/lnp-core?branch=exp/ln-interop#001086387a8882f65ce650df6732ab2fa6278ff9"
 dependencies = [
  "amplify",
  "bitcoin",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -120,3 +120,12 @@ tor = ["microservices/tor", "internet2/tor"]
 
 [package.metadata.configure_me]
 spec = "config_spec.toml"
+
+[patch.crates-io]
+# TODO: Remove after merge and release:
+#    - https://github.com/LNP-WG/lnp-core/pull/29
+#    - https://github.com/LNP-WG/lnp-core/pull/27
+lnp-core = { git = "https://github.com/crisdut/lnp-core", branch="exp/ln-interop" }
+# TODO: Remove after merge and release:
+#    - https://github.com/LNP-WG/lightning_encoding/pull/4
+lightning_encoding = { git = "https://github.com/crisdut/lightning_encoding", branch="fix/script-decode" }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -44,12 +44,13 @@ required-features = ["server"]
 
 [dependencies]
 # LNP/BP crates
-amplify = "3.14.1"
+amplify = "3.13.0"
 strict_encoding = { version = "0.9.0-rc.2", features = ["miniscript"] }
 bitcoin_scripts = "0.9.0"
 bitcoin_blockchain = "0.9.0"
 descriptor-wallet = { version = "0.9.0", features = ["keygen", "miniscript", "electrum", "sign", "construct"] }
 lnpbp = "0.9.0"
+lnpbp-invoice = { version = "0.9.0", features = ["serde", "bolt11"] }
 lnp-core = "0.9.1"
 lnp_rpc = { version = "0.9.1", path = "./rpc" }
 internet2 = { version = "0.9.0", features = ["keygen"] }
@@ -129,3 +130,6 @@ lnp-core = { git = "https://github.com/crisdut/lnp-core", branch="exp/ln-interop
 # TODO: Remove after merge and release:
 #    - https://github.com/LNP-WG/lightning_encoding/pull/4
 lightning_encoding = { git = "https://github.com/crisdut/lightning_encoding", branch="fix/script-decode" }
+# TODO: Remove after merge and release:
+#    - https://github.com/LNP-BP/invoices/pull/9
+lnpbp-invoice = { git = "https://github.com/crisdut/invoices", branch="feat/bolt11" }

--- a/cli/Cargo.toml
+++ b/cli/Cargo.toml
@@ -25,6 +25,7 @@ microservices = { version = "0.9.0", default-features = false, features = ["cli"
 shellexpand = "2.1"
 clap = { version = "~3.2.23", features = ["derive", "env"] }
 log = "0.4.14"
+colored = "2.0.0"
 
 [build-dependencies]
 amplify = "3.13.0"

--- a/cli/src/command.rs
+++ b/cli/src/command.rs
@@ -13,9 +13,12 @@
 
 use std::str::FromStr;
 
+use colored::Colorize;
 use internet2::addr::NodeId;
 use lnp::p2p::bolt::{ChannelId, LNP2P_BOLT_PORT};
-use lnp_rpc::{self, Client, CreateChannel, Error, ListenAddr, PayInvoice, RpcMsg, ServiceId};
+use lnp_rpc::{
+    self, Client, CreateChannel, CreateInvoice, Error, ListenAddr, PayInvoice, RpcMsg, ServiceId,
+};
 use microservices::shell::Exec;
 
 use crate::{Command, Opts};
@@ -152,7 +155,29 @@ impl Exec for Opts {
                 )?;
                 runtime.report_progress()?;
             }
-            Command::Invoice { .. } => todo!("Implement invoice generation"),
+            Command::Invoice { amount, description, bolt, .. } => {
+                if bolt {
+                    runtime.request(
+                        ServiceId::LnpBroker,
+                        RpcMsg::CreateInvoice(CreateInvoice {
+                            amount_msat: (amount * 1000),
+                            description,
+                        }),
+                    )?;
+                    runtime.report_response()?;
+                    eprintln!(
+                        "{} {}",
+                        "Warning:".bright_yellow(),
+                        "This is a experimental feature!".yellow()
+                    );
+                } else {
+                    eprintln!(
+                        "{} {}",
+                        "Error:".bright_red(),
+                        "Bifrost invoice does not implemented yet!".red()
+                    );
+                }
+            }
 
             Command::Pay { invoice, channel: channel_id, amount_msat } => {
                 runtime.request(

--- a/cli/src/opts.rs
+++ b/cli/src/opts.rs
@@ -214,6 +214,9 @@ pub enum Command {
 
     /// Create an invoice
     Invoice {
+        /// Invoice Description and/or Propouse
+        description: String,
+
         /// Asset amount to invoice, in atomic unit (satoshis or smallest asset
         /// unit type)
         amount: u64,
@@ -221,6 +224,14 @@ pub enum Command {
         /// Asset ticker in which the invoice should be issued
         #[clap(default_value = "btc")]
         asset: String,
+
+        /// Use BOLT lightning network protocol.
+        #[clap(long, conflicts_with = "bifrost")]
+        bolt: bool,
+
+        /// Use Bifrost lightning network protocol.
+        #[clap(long, required_unless_present = "bolt")]
+        bifrost: bool,
     },
 
     /// Pay the invoice

--- a/rpc/Cargo.toml
+++ b/rpc/Cargo.toml
@@ -19,6 +19,7 @@ strict_encoding = "0.9.0"
 bitcoin_scripts = "0.9.0"
 lnp-core = { version = "0.9.0", default-features = false }
 lnpbp = "0.9.0"
+lnpbp-invoice = { version = "0.9.0", features = ["serde", "bolt11"] }
 bitcoin = { version = "0.29.2", features = ["rand"] }
 lightning-invoice = { version = "0.21.0", optional = true }
 internet2 = "0.9.0"

--- a/shell/_lnp-cli
+++ b/shell/_lnp-cli
@@ -141,10 +141,13 @@ _arguments "${_arguments_options[@]}" \
 _arguments "${_arguments_options[@]}" \
 '-R+[ZMQ socket for connecting daemon RPC interface]:CONNECT: ' \
 '--rpc=[ZMQ socket for connecting daemon RPC interface]:CONNECT: ' \
+'(--bifrost)--bolt[Use BOLT lightning network protocol]' \
+'--bifrost[Use Bifrost lightning network protocol]' \
 '-h[Print help information]' \
 '--help[Print help information]' \
 '*-v[Set verbosity level]' \
 '*--verbose[Set verbosity level]' \
+':description -- Invoice Description and/or Propouse:' \
 ':amount -- Asset amount to invoice, in atomic unit (satoshis or smallest asset unit type):' \
 '::asset -- Asset ticker in which the invoice should be issued:' \
 && ret=0

--- a/shell/_lnp-cli.ps1
+++ b/shell/_lnp-cli.ps1
@@ -137,6 +137,8 @@ Register-ArgumentCompleter -Native -CommandName 'lnp-cli' -ScriptBlock {
         'lnp-cli;invoice' {
             [CompletionResult]::new('-R', 'R', [CompletionResultType]::ParameterName, 'ZMQ socket for connecting daemon RPC interface')
             [CompletionResult]::new('--rpc', 'rpc', [CompletionResultType]::ParameterName, 'ZMQ socket for connecting daemon RPC interface')
+            [CompletionResult]::new('--bolt', 'bolt', [CompletionResultType]::ParameterName, 'Use BOLT lightning network protocol')
+            [CompletionResult]::new('--bifrost', 'bifrost', [CompletionResultType]::ParameterName, 'Use Bifrost lightning network protocol')
             [CompletionResult]::new('-h', 'h', [CompletionResultType]::ParameterName, 'Print help information')
             [CompletionResult]::new('--help', 'help', [CompletionResultType]::ParameterName, 'Print help information')
             [CompletionResult]::new('-v', 'v', [CompletionResultType]::ParameterName, 'Set verbosity level')

--- a/shell/lnp-cli.bash
+++ b/shell/lnp-cli.bash
@@ -184,7 +184,7 @@ _lnp-cli() {
             return 0
             ;;
         lnp__cli__invoice)
-            opts="-h -R -v --help --rpc --verbose <AMOUNT> <ASSET>"
+            opts="-h -R -v --bolt --bifrost --help --rpc --verbose <DESCRIPTION> <AMOUNT> <ASSET>"
             if [[ ${cur} == -* || ${COMP_CWORD} -eq 2 ]] ; then
                 COMPREPLY=( $(compgen -W "${opts}" -- "${cur}") )
                 return 0

--- a/src/bus/ctl.rs
+++ b/src/bus/ctl.rs
@@ -67,8 +67,8 @@ pub enum CtlMsg {
     #[display("funding_constructed(...)")]
     FundingConstructed(Psbt),
 
-    /// Constructs first commitment transaction PSBT (aka. refund transaction) for penalty transactions
-    /// to remotely-created new channel. Sent from peerd to lnpd.
+    /// Constructs first commitment transaction PSBT (aka. refund transaction) for penalty
+    /// transactions to remotely-created new channel. Sent from peerd to lnpd.
     #[display("construct_refund({0})")]
     ConstructRefund(RefundParams),
 
@@ -97,7 +97,7 @@ pub enum CtlMsg {
     /// Reports changes in the mining status for previously requested transaction tracked by an
     /// on-chain service
     #[display("tx_found({0})")]
-    TxFound(TxStatus),
+    TxFound(TxConfirmation),
 
     // Routing & payments
     /// Request to channel daemon to perform payment using provided route
@@ -290,6 +290,19 @@ pub struct TxStatus {
 
     /// Optional block position given only if the depth is greater than 0 zero
     pub block_pos: Option<BlockPos>,
+}
+
+/// TODO: Move to descriptor wallet
+/// Update on a transaction mining status
+#[derive(Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash, Debug, Display)]
+#[derive(NetworkEncode, NetworkDecode)]
+#[display("{txid}, ...")]
+pub struct TxConfirmation {
+    /// Id of a transaction previously requested to be tracked
+    pub txid: Txid,
+
+    /// block confirmations
+    pub confirmations: u32,
 }
 
 #[derive(Clone, PartialEq, Eq, PartialOrd, Ord, Hash, Debug, Display, NetworkEncode, NetworkDecode)]

--- a/src/channeld/automata/mod.rs
+++ b/src/channeld/automata/mod.rs
@@ -107,6 +107,9 @@ pub enum ChannelStateMachine {
     #[from]
     Accept(ChannelAccept),
 
+    // /// receving commitment sign by a remote peer
+    // #[display("COMMITMENT")]
+    // Commitment(ReceivedHtlc),
     /// active channel operations
     #[display("ACTIVE")]
     Active,
@@ -192,8 +195,8 @@ impl Runtime {
             self.report_failure(endpoints, Failure { code, info });
         }
 
-        let event = Event::with(endpoints, self.identity(), source, request);
         let channel_id = self.state.channel.active_channel_id();
+        let event = Event::with(endpoints, self.identity(), source, request);
         let updated_state = match self.process_event(event) {
             Ok(_) => {
                 // Ignoring possible reporting errors here and after: do not want to
@@ -246,6 +249,11 @@ impl Runtime {
             )?;
             return Ok(());
         }
+
+        // if let BusMsg::Bolt(LnMsg::UpdateAddHtlc(_)) = event.message {
+        //     self.state.state_machine = self.complete_commitment(event)?;
+        //     return Ok(());
+        // }
 
         self.state.state_machine = match self.state.state_machine {
             ChannelStateMachine::Launch => self.complete_launch(event),

--- a/src/channeld/automata/propose.rs
+++ b/src/channeld/automata/propose.rs
@@ -211,7 +211,7 @@ fn complete_accepted(
     debug!("Funding transaction id is {}", funding_psbt.to_txid());
 
     let channel = &mut runtime.state.channel;
-    let refund_psbt = channel.refund_tx(funding_psbt, false)?;
+    let refund_psbt = channel.refund_tx(funding_psbt, true)?;
 
     trace!("Refund transaction: {:#?}", refund_psbt);
     trace!("Local keyset: {:#}", channel.constructor().local_keys());
@@ -283,7 +283,11 @@ fn complete_funding(
 
     let txid = runtime.state.channel.funding().txid();
     debug!("Waiting for funding transaction {} to be mined", txid);
-    runtime.send_ctl(event.endpoints, ServiceId::Watch, CtlMsg::Track { txid, depth: 0 })?;
+    let core = runtime.state.channel.constructor();
+    runtime.send_ctl(event.endpoints, ServiceId::Watch, CtlMsg::Track {
+        txid,
+        depth: core.common_params().minimum_depth,
+    })?;
 
     Ok(ChannelPropose::Published)
 }

--- a/src/channeld/automata/propose.rs
+++ b/src/channeld/automata/propose.rs
@@ -211,7 +211,7 @@ fn complete_accepted(
     debug!("Funding transaction id is {}", funding_psbt.to_txid());
 
     let channel = &mut runtime.state.channel;
-    let refund_psbt = channel.refund_tx(funding_psbt, true)?;
+    let refund_psbt = channel.refund_tx(funding_psbt, false)?;
 
     trace!("Refund transaction: {:#?}", refund_psbt);
     trace!("Local keyset: {:#}", channel.constructor().local_keys());

--- a/src/channeld/automata/propose.rs
+++ b/src/channeld/automata/propose.rs
@@ -211,7 +211,7 @@ fn complete_accepted(
     debug!("Funding transaction id is {}", funding_psbt.to_txid());
 
     let channel = &mut runtime.state.channel;
-    let refund_psbt = channel.refund_tx(funding_psbt, false)?;
+    let refund_psbt = channel.refund_tx(funding_psbt, true)?;
 
     trace!("Refund transaction: {:#?}", refund_psbt);
     trace!("Local keyset: {:#}", channel.constructor().local_keys());
@@ -261,7 +261,6 @@ fn complete_signing(
         .expect("unable to change ZMQ channel identity");
     // needed to update ESB routing map
     runtime.send_ctl(event.endpoints, ServiceId::LnpBroker, CtlMsg::Hello)?;
-
     runtime.send_p2p(event.endpoints, LnMsg::FundingCreated(funding_created))?;
     Ok(ChannelPropose::Funding)
 }

--- a/src/channeld/runtime.rs
+++ b/src/channeld/runtime.rs
@@ -243,6 +243,7 @@ impl Runtime {
             }
 
             CtlMsg::FundingConstructed(_)
+            | CtlMsg::RefundConstructed(..)
             | CtlMsg::TxFound(_)
             | CtlMsg::Signed(_)
             | CtlMsg::Keyset(..)

--- a/src/channeld/runtime.rs
+++ b/src/channeld/runtime.rs
@@ -200,11 +200,12 @@ impl Runtime {
                 );
             }
 
-            LnMsg::ChannelReestablish(_)
-            | LnMsg::AcceptChannel(_)
+            LnMsg::AcceptChannel(_)
             | LnMsg::FundingCreated(_)
             | LnMsg::FundingSigned(_)
-            | LnMsg::FundingLocked(_) => {
+            | LnMsg::FundingLocked(_)
+            | LnMsg::ChannelReestablish(_)
+            | LnMsg::UpdateAddHtlc(_) => {
                 self.process(endpoints, ServiceId::PeerBolt(remote_id), BusMsg::Bolt(message))?;
             }
             _ => {

--- a/src/lnpd/runtime.rs
+++ b/src/lnpd/runtime.rs
@@ -411,6 +411,16 @@ impl Runtime {
                     .insert(ChannelId::from_inner(launcher.channel_id()).into(), launcher);
             }
 
+            CtlMsg::ConstructRefund(refund_params) => {
+                let (psbt, outpoint) = self.funding_wallet.construct_refund_psbt(refund_params)?;
+                endpoints.send_to(
+                    ServiceBus::Ctl,
+                    self.identity(),
+                    source,
+                    BusMsg::Ctl(CtlMsg::RefundConstructed(psbt, outpoint)),
+                )?;
+            }
+
             CtlMsg::PublishFunding => {
                 let launcher = self
                     .creating_channels

--- a/src/peerd/runtime.rs
+++ b/src/peerd/runtime.rs
@@ -188,12 +188,11 @@ impl esb::Handler<ServiceBus> for Runtime {
     fn on_ready(&mut self, _: &mut Endpoints) -> Result<(), Error> {
         if self.connect {
             info!("{} with the remote peer", "Initializing connection".announce());
-
             match self.config.protocol {
                 p2p::Protocol::Bolt => {
                     self.sender.send_message(bolt::Messages::Init(bolt::Init {
-                        global_features: InitFeatures::default(),
-                        local_features: InitFeatures::default(),
+                        global_features: InitFeatures::new(),
+                        local_features: InitFeatures::new(),
                         assets: none!(),
                         unknown_tlvs: none!(),
                     }))?;

--- a/src/peerd/runtime.rs
+++ b/src/peerd/runtime.rs
@@ -402,6 +402,7 @@ impl Runtime {
 
             bolt::Messages::FundingSigned(bolt::FundingSigned { channel_id, .. })
             | bolt::Messages::FundingLocked(bolt::FundingLocked { channel_id, .. })
+            | bolt::Messages::CommitmentSigned(bolt::CommitmentSigned { channel_id, .. })
             | bolt::Messages::UpdateAddHtlc(bolt::UpdateAddHtlc { channel_id, .. })
             | bolt::Messages::UpdateFulfillHtlc(bolt::UpdateFulfillHtlc { channel_id, .. })
             | bolt::Messages::UpdateFailHtlc(bolt::UpdateFailHtlc { channel_id, .. })

--- a/src/watchd/runtime.rs
+++ b/src/watchd/runtime.rs
@@ -88,16 +88,14 @@ impl WatcherRuntime {
         // TODO: Forward all electrum notifications over the bridge
         // self.send_over_bridge(msg.into()).expect("watcher bridge is halted");
         match msg {
-            ElectrumUpdate::TxBatch(transactions, _) => {
+            ElectrumUpdate::TxConfirmations(transactions, _) => {
                 for transaction in transactions {
-                    self.send_over_bridge(BusMsg::Ctl(CtlMsg::TxFound(crate::bus::TxStatus {
-                        txid: transaction.txid(),
-                        block_pos: None,
-                    })))
-                    .expect("unable forward electrum notifications over the bridge");
+                    self.send_over_bridge(BusMsg::Ctl(CtlMsg::TxFound(transaction)))
+                        .expect("unable forward electrum notifications over the bridge");
                 }
             }
-            ElectrumUpdate::Connecting
+            ElectrumUpdate::TxBatch(..)
+            | ElectrumUpdate::Connecting
             | ElectrumUpdate::Connected
             | ElectrumUpdate::Complete
             | ElectrumUpdate::FeeEstimate(..)
@@ -170,7 +168,7 @@ impl Runtime {
         match request {
             CtlMsg::TxFound(tx_status) => {
                 if let Some((required_height, service_id)) = self.track_list.get(&tx_status.txid) {
-                    if *required_height >= tx_status.block_pos.map(|b| b.pos).unwrap_or_default() {
+                    if *required_height <= tx_status.confirmations {
                         let service_id = service_id.clone();
                         self.untrack(tx_status.txid);
                         match self.electrum_worker.untrack_transaction(tx_status.txid) {

--- a/src/watchd/worker.rs
+++ b/src/watchd/worker.rs
@@ -13,12 +13,15 @@
 
 // TODO: Consider making it part of descriptor wallet onchain library
 
+use std::collections::BTreeMap;
 use std::sync::mpsc;
 use std::thread::{self, JoinHandle};
 use std::time::Duration;
 
-use bitcoin::{Transaction, Txid};
+use bitcoin::{Script, Transaction, Txid};
 use electrum_client::{Client as ElectrumClient, ElectrumApi, HeaderNotification};
+
+use crate::bus::TxConfirmation;
 
 #[derive(Copy, Clone, Ord, PartialOrd, Eq, PartialEq, Hash, Debug, Display, Error, From)]
 #[display("failed electrum watcher channel")]
@@ -47,6 +50,9 @@ pub enum ElectrumUpdate {
 
     #[display("tx_batch(...)")]
     TxBatch(Vec<Transaction>, f32),
+
+    #[display("tx_confirmations(...)")]
+    TxConfirmations(Vec<TxConfirmation>, u32),
 
     #[display("channel_disconnected")]
     ChannelDisconnected,
@@ -193,7 +199,42 @@ impl ElectrumProcessor {
         if self.tracks.is_empty() {
             return Ok(None);
         }
-        self.client.batch_transaction_get(txids).map(|res| Some(ElectrumUpdate::TxBatch(res, 0.0)))
+        let transactions = self.client.batch_transaction_get(txids)?;
+        let scripts: Vec<Script> =
+            transactions.into_iter().map(|tx| tx.output[0].script_pubkey.clone()).collect();
+
+        let hist = self.client.batch_script_get_history(&scripts)?;
+
+        let mut items = vec![];
+        hist.into_iter().for_each(|mut item| items.append(&mut item));
+
+        if items.is_empty() {
+            return Ok(None);
+        }
+
+        let transactions: BTreeMap<Txid, i32> =
+            items.into_iter().map(|h| (h.tx_hash, h.height)).collect();
+
+        let min_height = transactions.clone().into_iter().map(|(_, h)| h).min();
+        let min_height = min_height.unwrap_or_default();
+
+        let block_headers = self.client.block_headers(min_height as usize, 50)?;
+        let block_total = block_headers.headers.len() as i32;
+
+        let confirmations: BTreeMap<Txid, i32> = transactions
+            .into_iter()
+            .filter(|(_, height)| min_height + block_total > height.to_owned())
+            .collect();
+
+        let confirmations: Vec<TxConfirmation> = confirmations
+            .into_iter()
+            .map(|(tx_id, height)| TxConfirmation {
+                txid: tx_id,
+                confirmations: (min_height + block_total - height) as u32,
+            })
+            .collect();
+
+        Ok(Some(ElectrumUpdate::TxConfirmations(confirmations.clone(), confirmations.len() as u32)))
     }
 
     fn track_transaction(


### PR DESCRIPTION
this PR completes all steps to interop with another lightning implementations.

I resolved open this PR as a **draft** because I will change many parts of the **lnp-node** and **lnp-core** and would like to get feedback from other contributors before finalizing the PR.

**Pending items to Ready to Review** 
- [x] Add support to minimum depth in `watchd`;
- [x] Add Universal Invoice (LNPBP-38) to BOLT payments;
- [ ] Complete the **Nodes Tests** list (see bellow);
- [x] Update crates with dependencies (see section "Dependencies").

**Nodes Tests**
I marked all tests I finish in the below list:

- [x] Connect peer and open a channel from `lnp` to `lnp`;
- [x] Connect peer and open a channel from `lnp` to `lnd`;
- [x] Connect peer and open a channel from `lnp` to `cligntning`; 
- [x] Connect peer and open a channel from `lnd` to `lnp`;
- [x] Connect peer and open a channel from `cligntning` to `lnp`;
- [ ] The `lnd` create an invoice and `lnp` payed;
- [ ] The `cligntning` create an invoice and `lnp` payed;
- [ ] The `lnp` create an invoice and `lnp` payed;
- [ ] The `lnp` create an invoice and `lnd` payed;
- [x] The `lnp` create an invoice and `cligntning` payed;
- [ ] The `lnp` unilaterally closes the channel and publish **penalty transaction**;
- [x] The `lnd` unilaterally closes the channel and publish **penalty transaction**;
- [x] The `cligntning` unilaterally closes the channel and publish **penalty transaction**;
- [ ] The `lnp` and `lnp` closes the channel mutually;
- [ ] The `lnp` and `lnd` closes the channel mutually;
- [ ] The `lnp` and `cligntning` closes the channel mutually;
 
**Dependencies**
- LNP-WG/lnp-core/pull/29
- LNP-WG/lnp-core/pull/27
- LNP-WG/lightning_encoding/pull/4
- LNP-BP/invoices/pull/9

Feedback are welcome, thanks!
